### PR TITLE
fix: Дублирующие заголовки `Price` и `Currency` при передаче нескольк…

### DIFF
--- a/src/ValueObject/ConversionHeader.php
+++ b/src/ValueObject/ConversionHeader.php
@@ -98,10 +98,9 @@ class ConversionHeader
 	 */
 	public function addUsesColumn($name)
 	{
-		
-		if (in_array($name, self::$availableColumns)) {
-			$this->usesColumns[] = $name;
-		}
+        if (in_array($name, self::$availableColumns) && !in_array($name, $this->usesColumns)) {
+            $this->usesColumns[] = $name;
+        }
 	}
 	
 	/**


### PR DESCRIPTION
…их конверсий

Метод `\Meiji\YandexMetrikaOffline\Scope\Upload::addConversion` при добавлении конверсии, при наличии `Price` и `Currency` — добавляет одноименные столбцы через \Meiji\YandexMetrikaOffline\ValueObject\ConversionHeader::addUsesColumn. Но данный метод не проверяет есть ли уже такие столбцы, в результате — дублирующий вывод информации и ошибка от Яндекс.Метрики при передаче данных.